### PR TITLE
Add the wifi API

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "python.pythonPath": ".venv/bin/python3",
+  "python.pythonPath": ".venv/bin/python",
   "[python]": {
     "editor.tabSize": 4
   },

--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ status.put_status(air_purifier_host="192.168.1.12", status={"pwr": "1"})
 current_status = status.get_status(air_purifier_host="192.168.1.12")
 ```
 
+Connect your air purifier to your WiFi network:
+1. Set your air purifier to "pairing mode" (look online for instructions).
+2. Connect your computer to the WiFi network created by the air purifier.
+3. Run this:
+   ```python
+   from philips_air_purifier import wifi
+   wifi.put_wifi(air_purifier_host="192.168.1.1", ssid="your wifi's name", pwd="your wifi's password")
+   ```
+   At this point the air purifier will leave "pairing mode" and connect to your WiFi network.
+4. Re-connect to your WiFi network and find the IP address of the air purifier (by inspecting your router).
+
 ## TODO before 1.0.0
 - session-based API (to avoid the need to repeat DH key exchange for every call--to support more complicated use cases)
 - custom HTTP request API (to support features not covered by the functional and session-based API)

--- a/philips_air_purifier/wifi.py
+++ b/philips_air_purifier/wifi.py
@@ -1,0 +1,29 @@
+import json
+
+import requests
+
+from philips_air_purifier import comms
+
+
+def get_wifi(air_purifier_host):
+    session_key = comms.get_key(air_purifier_host)
+    wifi_url = comms.get_api_url(air_purifier_host, "0/wifi")
+    response = requests.get(wifi_url)
+    response.raise_for_status()
+    wifi_response = comms.dh_decrypt(response.text, session_key)
+    return json.loads(wifi_response)
+
+
+def put_wifi(air_purifier_host, ssid=None, pwd=None):
+    wifi_settings = {}
+    if ssid is not None:
+        wifi_settings["ssid"] = ssid
+    if pwd is not None:
+        wifi_settings["password"] = pwd
+    session_key = comms.get_key(air_purifier_host)
+    wifi_url = comms.get_api_url(air_purifier_host, "0/wifi")
+    encrypted_wifi_settings = comms.dh_encrypt(json.dumps(wifi_settings), session_key)
+    response = requests.put(wifi_url, data=encrypted_wifi_settings)
+    response.raise_for_status()
+    wifi_response = comms.dh_decrypt(response.text, session_key)
+    return json.loads(wifi_response)

--- a/tests/test_wifi.py
+++ b/tests/test_wifi.py
@@ -1,0 +1,13 @@
+from philips_air_purifier import wifi
+from tests import wifi_responses, mock_purifier
+
+
+def test_get_wifi():
+    with mock_purifier.MockPurifier() as session:
+        assert wifi_responses.UNCONFIGURED_WIFI == wifi.get_wifi(session.host)
+
+
+def test_put_status():
+    with mock_purifier.MockPurifier() as session:
+        wifi.put_wifi(session.host, ssid="foobar", pwd="supersecret")
+        assert "foobar" == wifi.get_wifi(session.host)["ssid"]

--- a/tests/wifi_responses.py
+++ b/tests/wifi_responses.py
@@ -1,0 +1,25 @@
+UNCONFIGURED_WIFI = {
+    "ssid": "PHILIPS Setup",
+    "password": "",
+    "protection": "open",
+    "ipaddress": "192.168.1.1",
+    "netmask": "255.255.255.0",
+    "gateway": "192.168.1.1",
+    "dhcp": True,
+    "macaddress": "e8:c1:d7:07:c3:20",
+    "cppid": "e8c1d7fffe07c320",
+}
+
+
+def configured_wifi(ssid):
+    return {
+        "ssid": ssid,
+        "password": "",  # the purifier seems to actually hide the password
+        "protection": "wpa-2",
+        "ipaddress": "192.168.1.105",
+        "netmask": "255.255.255.0",
+        "gateway": "192.168.1.1",
+        "dhcp": True,
+        "macaddress": "e8:c1:d7:07:c3:20",
+        "cppid": "e8c1d7fffe07c320",
+    }


### PR DESCRIPTION
This change adds the module `philips_air_purifier.wifi`. This module contains two functions: `get_wifi` and `put_wifi`.

This change also adds `README.md` instructions on how to connect your air purifier to your WiFi.